### PR TITLE
Fix hardcoded temp dir and added missing min max values for OmniGen2

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -10,6 +10,7 @@ from .omnigen2.pipelines.omnigen2.pipeline_omnigen2 import OmniGen2Pipeline
 from .omnigen2.utils.img_util import resize_image
 
 #from diffusers.hooks import apply_group_offloading # only exists in very recent commits of diffusers
+
 import folder_paths
 import numpy as np
 
@@ -227,3 +228,6 @@ class OmniGen2:
         collage = pil2tensor(Image.open(collage_tmp_path).convert("RGB"))
         
         return (collage, images,)
+
+
+


### PR DESCRIPTION
It is important that the temp directory must be retrieved via: **`temp_dir = folder_paths.get_temp_directory()`** - because it can be changed in ComfyUI settings.